### PR TITLE
Separate types to standalone pacakages

### DIFF
--- a/.github/workflows/cpp-code-style-checker.yml
+++ b/.github/workflows/cpp-code-style-checker.yml
@@ -1,0 +1,36 @@
+name: Cpp Code Style Checker
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  cpp-code-style-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install clang-format
+      run: sudo apt install -y clang-format
+
+    - name: Setup clang-format configuration
+      run: |
+        if [ ! -f ./.clang-format ]; then
+          echo "No .clang-format found, will use default configuration"
+          curl -o .clang-format https://raw.githubusercontent.com/quic-qrb-ros/.github/main/code-style-profiles/.clang-format
+        fi
+
+    - name: Check code style
+      run: |
+        SRC=$(git ls-tree --full-tree -r HEAD | grep -e "\.\(c\|h\|hpp\|cpp\)\$" | cut -f 2)
+
+        echo -e "Check source files: \n$SRC\n"
+        clang-format -style=file -i $SRC
+
+        if ! git diff --exit-code; then
+          echo -e "\nCode does not match required style !!!"
+          echo "Please use clang-format to format your code."
+          exit 1
+        else
+          echo "All files are properly formatted."
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for package qrb_ros_transport
 
+## 1.2.0 (2024-10-26)
+
+- Separate Image and IMU types to standalone packages
+- Contributors: Peng Wang
+
 ## 1.1.0 (2024-07-12)
 
 - Add IMU transport support

--- a/qrb_ros_transport_image_type/CMakeLists.txt
+++ b/qrb_ros_transport_image_type/CMakeLists.txt
@@ -1,18 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(qrb_ros_transport)
-
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+project(qrb_ros_transport_image_type)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic --std=c++17)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -22,8 +12,7 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
-  src/type/image.cpp
-  src/type/imu.cpp
+  src/image.cpp
   src/image_utils.cpp
 )
 
@@ -42,13 +31,6 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(${PROJECT_NAME}_image_utils_test
     test/image_utils_test.cpp
   )
-
-  ament_auto_add_gtest(${PROJECT_NAME}_imu_test_pub test/imu_test.cpp)
-  target_compile_definitions(${PROJECT_NAME}_imu_test_pub PRIVATE "-DTEST_PUBLISHER")
-
-  ament_auto_add_gtest(${PROJECT_NAME}_imu_test_sub test/imu_test.cpp)
-  target_compile_definitions(${PROJECT_NAME}_imu_test_sub PRIVATE "-DTEST_SUBSCRIBER")
-
 endif()
 
-ament_auto_package()
+ament_package()

--- a/qrb_ros_transport_image_type/include/qrb_ros_transport_image_type/image.hpp
+++ b/qrb_ros_transport_image_type/include/qrb_ros_transport_image_type/image.hpp
@@ -1,14 +1,14 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#ifndef QRB_ROS_TRANSPORT__TYPE__IMAGE_HPP_
-#define QRB_ROS_TRANSPORT__TYPE__IMAGE_HPP_
+#ifndef QRB_ROS_TRANSPORT_IMAGE_TYPE__IMAGE_HPP_
+#define QRB_ROS_TRANSPORT_IMAGE_TYPE__IMAGE_HPP_
 
 #include <cstring>
 #include <memory>
 
 #include "lib_mem_dmabuf/dmabuf.hpp"
-#include "qrb_ros_transport/image_utils.hpp"
+#include "qrb_ros_transport_image_type/image_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/type_adapter.hpp"
 #include "sensor_msgs/image_encodings.hpp"
@@ -42,4 +42,4 @@ struct rclcpp::TypeAdapter<qrb_ros::transport::type::Image, sensor_msgs::msg::Im
 RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(qrb_ros::transport::type::Image,
     sensor_msgs::msg::Image);
 
-#endif  // QRB_ROS_TRANSPORT__TYPE__IMAGE_HPP_
+#endif  // QRB_ROS_TRANSPORT_IMAGE_TYPE__IMAGE_HPP_

--- a/qrb_ros_transport_image_type/include/qrb_ros_transport_image_type/image_utils.hpp
+++ b/qrb_ros_transport_image_type/include/qrb_ros_transport_image_type/image_utils.hpp
@@ -1,8 +1,8 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#ifndef QRB_ROS_TRANSPORT__IMAGE_UTILS_HPP_
-#define QRB_ROS_TRANSPORT__IMAGE_UTILS_HPP_
+#ifndef QRB_ROS_TRANSPORT_IMAGE_TYPE__IMAGE_UTILS_HPP_
+#define QRB_ROS_TRANSPORT_IMAGE_TYPE__IMAGE_UTILS_HPP_
 
 #include "lib_mem_dmabuf/dmabuf.hpp"
 #include "sensor_msgs/image_encodings.hpp"
@@ -44,4 +44,4 @@ bool read_image_from_dmabuf(std::shared_ptr<lib_mem_dmabuf::DmaBuffer> dmabuf,
 
 }  // namespace qrb_ros::transport::image_utils
 
-#endif  // QRB_ROS_TRANSPORT__IMAGE_UTILS_HPP_
+#endif  // QRB_ROS_TRANSPORT_IMAGE_TYPE__IMAGE_UTILS_HPP_

--- a/qrb_ros_transport_image_type/package.xml
+++ b/qrb_ros_transport_image_type/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>qrb_ros_transport</name>
-  <version>1.1.0</version>
-  <description>Type Adaption implementation on Qualcomm robotics platforms</description>
+  <name>qrb_ros_transport_image_type</name>
+  <version>1.2.0</version>
+  <description>Type Adaption for image on Qualcomm robotics platforms</description>
   <maintainer email="quic_penwang@quicinc.com">Peng Wang</maintainer>
   <license>BSD-3-Clause</license>
 
@@ -13,7 +13,6 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>lib_mem_dmabuf</depend>
-  <depend>qrb_sensor_client</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/qrb_ros_transport_image_type/src/image.cpp
+++ b/qrb_ros_transport_image_type/src/image.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#include "qrb_ros_transport/type/image.hpp"
+#include "qrb_ros_transport_image_type/image.hpp"
 
 void rclcpp::TypeAdapter<qrb_ros::transport::type::Image,
     sensor_msgs::msg::Image>::convert_to_ros_message(const custom_type & source,

--- a/qrb_ros_transport_image_type/src/image_utils.cpp
+++ b/qrb_ros_transport_image_type/src/image_utils.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#include "qrb_ros_transport/image_utils.hpp"
+#include "qrb_ros_transport_image_type/image_utils.hpp"
 
 #include <iostream>
 #include <map>

--- a/qrb_ros_transport_image_type/test/image_test.cpp
+++ b/qrb_ros_transport_image_type/test/image_test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#include "qrb_ros_transport/type/image.hpp"
+#include "qrb_ros_transport_image_type/image.hpp"
 
 #include <fstream>
 

--- a/qrb_ros_transport_image_type/test/image_utils_test.cpp
+++ b/qrb_ros_transport_image_type/test/image_utils_test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#include "qrb_ros_transport/image_utils.hpp"
+#include "qrb_ros_transport_image_type/image_utils.hpp"
 
 #include "gtest/gtest.h"
 

--- a/qrb_ros_transport_imu_type/CMakeLists.txt
+++ b/qrb_ros_transport_imu_type/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.8)
+project(qrb_ros_transport_imu_type)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic --std=c++17)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# find dependencies
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/imu.cpp
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(${PROJECT_NAME}_imu_test_pub test/imu_test.cpp)
+  target_compile_definitions(${PROJECT_NAME}_imu_test_pub PRIVATE "-DTEST_PUBLISHER")
+
+  ament_auto_add_gtest(${PROJECT_NAME}_imu_test_sub test/imu_test.cpp)
+  target_compile_definitions(${PROJECT_NAME}_imu_test_sub PRIVATE "-DTEST_SUBSCRIBER")
+endif()
+
+ament_package()

--- a/qrb_ros_transport_imu_type/include/qrb_ros_transport_imu_type/imu.hpp
+++ b/qrb_ros_transport_imu_type/include/qrb_ros_transport_imu_type/imu.hpp
@@ -1,8 +1,8 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#ifndef QRB_ROS_TRANSPORT__TYPE__IMU_HPP_
-#define QRB_ROS_TRANSPORT__TYPE__IMU_HPP_
+#ifndef QRB_ROS_TRANSPORT_IMU_TYPE__IMU_HPP_
+#define QRB_ROS_TRANSPORT_IMU_TYPE__IMU_HPP_
 
 #include "qrb_sensor_client/sensor_client.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -34,4 +34,4 @@ struct rclcpp::TypeAdapter<qrb_ros::transport::type::Imu, sensor_msgs::msg::Imu>
 
 RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(qrb_ros::transport::type::Imu, sensor_msgs::msg::Imu);
 
-#endif  // QRB_ROS_TRANSPORT__TYPE__IMU_HPP_
+#endif  // QRB_ROS_TRANSPORT_IMU_TYPE__IMU_HPP_

--- a/qrb_ros_transport_imu_type/package.xml
+++ b/qrb_ros_transport_imu_type/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>qrb_ros_transport_imu_type</name>
+  <version>1.2.0</version>
+  <description>Type Adaption for IMU on Qualcomm robotics platforms</description>
+  <maintainer email="quic_penwang@quicinc.com">Peng Wang</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>qrb_sensor_client</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/qrb_ros_transport_imu_type/src/imu.cpp
+++ b/qrb_ros_transport_imu_type/src/imu.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#include "qrb_ros_transport/type/imu.hpp"
+#include "qrb_ros_transport_imu_type/imu.hpp"
 
 void rclcpp::TypeAdapter<qrb_ros::transport::type::Imu,
     sensor_msgs::msg::Imu>::convert_to_ros_message(const custom_type & source,

--- a/qrb_ros_transport_imu_type/test/imu_test.cpp
+++ b/qrb_ros_transport_imu_type/test/imu_test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 
-#include "qrb_ros_transport/type/imu.hpp"
+#include "qrb_ros_transport_imu_type/imu.hpp"
 
 class PubNode : public rclcpp::Node
 {


### PR DESCRIPTION
v1.2.0: separate types to standalone packages

It used to fix extra dependencies issue, such as `qbr_ros_camera` -> `qrb_ros_transport` -> `qrb_sensor_client`.