### PR TITLE
Fix type header export issue

### DIFF
--- a/qrb_ros_transport_image_type/CMakeLists.txt
+++ b/qrb_ros_transport_image_type/CMakeLists.txt
@@ -33,4 +33,4 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_package()
+ament_auto_package()

--- a/qrb_ros_transport_imu_type/CMakeLists.txt
+++ b/qrb_ros_transport_imu_type/CMakeLists.txt
@@ -28,4 +28,4 @@ if(BUILD_TESTING)
   target_compile_definitions(${PROJECT_NAME}_imu_test_sub PRIVATE "-DTEST_SUBSCRIBER")
 endif()
 
-ament_package()
+ament_auto_package()


### PR DESCRIPTION
Type headers not export, use `ament_auto_package()` to fix it